### PR TITLE
Allow to specify flags for managers

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,7 @@ excluded:
   - Pods
   - .build
   - Package.swift
-  - Sources/CartfileParser
+  - Sources/ThirtPartyDependencies
   - Tests
 
 # Rules

--- a/Sources/Depo/Helpers/AllPackagesManager+CLI.swift
+++ b/Sources/Depo/Helpers/AllPackagesManager+CLI.swift
@@ -27,6 +27,18 @@ extension AllPackagesManager: CLIPackageManager {
 
         @Flag()
         var frameworkKind: MergePackage.FrameworkKind = .fatFramework
+
+        @Flag()
+        var cacheBuilds: Bool = false
+
+        @Option(name: [.customLong("carthage-args"), .customShort(Character("c"))])
+        var carthageArguments: String?
+
+        @Option(name: [.customLong("pod-args")])
+        var podArguments: String?
+
+        @Option(name: [.customLong("swift-build-args"), .customShort(Character("s"))])
+        var swiftBuildArguments: String?
     }
 
     convenience init(depofile: Depofile, options: Options) {
@@ -35,6 +47,10 @@ extension AllPackagesManager: CLIPackageManager {
                   podCommandPath: options.podCommandPath,
                   carthageCommandPath: options.carthageCommandPath,
                   swiftCommandPath: options.swiftCommandPath,
-                  frameworkKind: options.frameworkKind)
+                  frameworkKind: options.frameworkKind,
+                  cacheBuilds: options.cacheBuilds,
+                  carthageArguments: options.carthageArguments,
+                  podArguments: options.podArguments,
+                  swiftBuildArguments: options.swiftBuildArguments)
     }
 }

--- a/Sources/Depo/Helpers/CarthageManager+CLI.swift
+++ b/Sources/Depo/Helpers/CarthageManager+CLI.swift
@@ -19,9 +19,19 @@ extension CarthageManager: CLIPackageManager {
 
         @Option(completion: .file())
         var carthageCommandPath: String = AppConfiguration.Path.Absolute.carthageCommandPath
+
+        @Flag()
+        var cacheBuilds: Bool = false
+
+        @Option(name: [.customLong("carthage-args"), .customShort(Character("c"))])
+        var carthageArguments: String?
     }
 
     convenience init(depofile: Depofile, options: Options) {
-        self.init(depofile: depofile, platform: options.platform, carthageCommandPath: options.carthageCommandPath)
+        self.init(depofile: depofile,
+                  platform: options.platform,
+                  carthageCommandPath: options.carthageCommandPath,
+                  cacheBuilds: options.cacheBuilds,
+                  carthageArguments: options.carthageArguments)
     }
 }

--- a/Sources/Depo/Helpers/PodManager+CLI.swift
+++ b/Sources/Depo/Helpers/PodManager+CLI.swift
@@ -22,7 +22,7 @@ extension PodManager: CLIPackageManager {
 
         @Flag()
         var cacheBuilds: Bool = false
-        
+
         @Option(name: [.customLong("pod-args")])
         var podArguments: String?
     }

--- a/Sources/Depo/Helpers/PodManager+CLI.swift
+++ b/Sources/Depo/Helpers/PodManager+CLI.swift
@@ -19,9 +19,19 @@ extension PodManager: CLIPackageManager {
 
         @Flag()
         var frameworkKind: MergePackage.FrameworkKind = .fatFramework
+
+        @Flag()
+        var cacheBuilds: Bool = false
+        
+        @Option(name: [.customLong("pod-args")])
+        var podArguments: String?
     }
 
     convenience init(depofile: Depofile, options: Options) {
-        self.init(depofile: depofile, podCommandPath: options.podCommandPath, frameworkKind: options.frameworkKind)
+        self.init(depofile: depofile,
+                  podCommandPath: options.podCommandPath,
+                  frameworkKind: options.frameworkKind,
+                  cacheBuilds: options.cacheBuilds,
+                  podArguments: options.podArguments)
     }
 }

--- a/Sources/Depo/Helpers/SPMManager+CLI.swift
+++ b/Sources/Depo/Helpers/SPMManager+CLI.swift
@@ -22,10 +22,10 @@ extension SPMManager: HasUpdateCommand, HasBuildCommand {
 
         @Flag()
         var cacheBuilds: Bool = false
-        
+
         @Option(name: [.customLong("swift-build-args"), .customShort(Character("s"))])
         var swiftBuildArguments: String?
-        
+
     }
 
     convenience init(depofile: Depofile, options: Options) {

--- a/Sources/Depo/Helpers/SPMManager+CLI.swift
+++ b/Sources/Depo/Helpers/SPMManager+CLI.swift
@@ -19,9 +19,20 @@ extension SPMManager: HasUpdateCommand, HasBuildCommand {
 
         @Flag()
         var frameworkKind: MergePackage.FrameworkKind = .fatFramework
+
+        @Flag()
+        var cacheBuilds: Bool = false
+        
+        @Option(name: [.customLong("swift-build-args"), .customShort(Character("s"))])
+        var swiftBuildArguments: String?
+        
     }
 
     convenience init(depofile: Depofile, options: Options) {
-        self.init(depofile: depofile, swiftCommandPath: options.swiftCommandPath, frameworkKind: options.frameworkKind)
+        self.init(depofile: depofile,
+                  swiftCommandPath: options.swiftCommandPath,
+                  frameworkKind: options.frameworkKind,
+                  cacheBuilds: options.cacheBuilds,
+                  swiftBuildArguments: options.swiftBuildArguments)
     }
 }

--- a/Sources/Depo/UI/MergePackageState+UI.swift
+++ b/Sources/Depo/UI/MergePackageState+UI.swift
@@ -14,4 +14,3 @@ extension MergePackage.State: CustomStringConvertible {
         }
     }
 }
-

--- a/Sources/DepoCore/Helpers/Bool+Map.swift
+++ b/Sources/DepoCore/Helpers/Bool+Map.swift
@@ -1,0 +1,14 @@
+//
+// Copyright © 2021 Rosberry. All rights reserved.
+//
+
+extension Bool {
+    func mapTrue<T>(to value: T) -> T? {
+        if self {
+            return value
+        }
+        else {
+            return nil
+        }
+    }
+}

--- a/Sources/DepoCore/Helpers/Bool+Map.swift
+++ b/Sources/DepoCore/Helpers/Bool+Map.swift
@@ -4,11 +4,6 @@
 
 extension Bool {
     func mapTrue<T>(to value: T) -> T? {
-        if self {
-            return value
-        }
-        else {
-            return nil
-        }
+        self ? value : nil
     }
 }

--- a/Sources/DepoCore/Helpers/HasEmptyValue.swift
+++ b/Sources/DepoCore/Helpers/HasEmptyValue.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2021 Rosberry. All rights reserved.
+//
+
+public protocol HasEmptyValue {
+    static var emptyValue: Self { get }
+}
+
+extension Array: HasEmptyValue {
+    public static var emptyValue: Array<Element> {
+        []
+    }
+}
+
+extension String: HasEmptyValue {
+    public static var emptyValue: String {
+        ""
+    }
+}

--- a/Sources/DepoCore/Helpers/Optional+Convenience.swift
+++ b/Sources/DepoCore/Helpers/Optional+Convenience.swift
@@ -2,10 +2,28 @@
 // Copyright © 2021 Rosberry. All rights reserved.
 //
 
-extension Optional {
+public extension Optional {
     var array: [Wrapped] {
         map { wrapped in
             [wrapped]
         } ?? []
+    }
+
+    func map<T>(keyPath: KeyPath<Wrapped, T>) -> T? {
+        map { wrapped in
+            wrapped[keyPath: keyPath]
+        }
+    }
+
+    func mapOrDefault<T: HasDefaultValue>(keyPath: KeyPath<Wrapped, T>) -> T {
+        map { wrapped in
+            wrapped[keyPath: keyPath]
+        } ?? T.defaultValue
+    }
+
+    func mapOrEmpty<T: HasEmptyValue>(keyPath: KeyPath<Wrapped, T>) -> T {
+        map { wrapped in
+            wrapped[keyPath: keyPath]
+        } ?? T.emptyValue
     }
 }

--- a/Sources/DepoCore/Helpers/Optional+Convenience.swift
+++ b/Sources/DepoCore/Helpers/Optional+Convenience.swift
@@ -9,12 +9,6 @@ public extension Optional {
         } ?? []
     }
 
-    func map<T>(keyPath: KeyPath<Wrapped, T>) -> T? {
-        map { wrapped in
-            wrapped[keyPath: keyPath]
-        }
-    }
-
     func mapOrDefault<T: HasDefaultValue>(keyPath: KeyPath<Wrapped, T>) -> T {
         map { wrapped in
             wrapped[keyPath: keyPath]

--- a/Sources/DepoCore/Helpers/Optional+Convenience.swift
+++ b/Sources/DepoCore/Helpers/Optional+Convenience.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2021 Rosberry. All rights reserved.
+//
+
+extension Optional {
+    var array: [Wrapped] {
+        map { wrapped in
+            [wrapped]
+        } ?? []
+    }
+}

--- a/Sources/DepoCore/Helpers/String+Convenience.swift
+++ b/Sources/DepoCore/Helpers/String+Convenience.swift
@@ -9,4 +9,10 @@ public extension String {
     subscript(from index: Index) -> Substring {
         self[index..<self.index(startIndex, offsetBy: count)]
     }
+
+    var words: [String] {
+        split(separator: " ").map { substring in
+            String(substring)
+        }
+    }
 }

--- a/Sources/DepoCore/PackageManagers/AllPackagesManager.swift
+++ b/Sources/DepoCore/PackageManagers/AllPackagesManager.swift
@@ -15,17 +15,29 @@ public final class AllPackagesManager: ProgressObservable {
     private let depofile: Depofile
     private let platform: Platform
     private var podManager: PodManager {
-        PodManager(depofile: depofile, podCommandPath: podCommandPath, frameworkKind: frameworkKind).subscribe { [weak self] state in
+        PodManager(depofile: depofile,
+                   podCommandPath: podCommandPath,
+                   frameworkKind: frameworkKind,
+                   cacheBuilds: cacheBuilds,
+                   podArguments: podArguments).subscribe { [weak self] state in
             self?.observer?(.podManager(state))
         }
     }
     private var carthageManager: CarthageManager {
-        CarthageManager(depofile: depofile, platform: platform, carthageCommandPath: carthageCommandPath).subscribe { [weak self] state in
+        CarthageManager(depofile: depofile,
+                        platform: platform,
+                        carthageCommandPath: carthageCommandPath,
+                        cacheBuilds: cacheBuilds,
+                        carthageArguments: carthageArguments).subscribe { [weak self] state in
             self?.observer?(.carthageManager(state))
         }
     }
     private var spmManager: SPMManager {
-        SPMManager(depofile: depofile, swiftCommandPath: swiftCommandPath, frameworkKind: frameworkKind).subscribe { [weak self] state in
+        SPMManager(depofile: depofile,
+                   swiftCommandPath: swiftCommandPath,
+                   frameworkKind: frameworkKind,
+                   cacheBuilds: cacheBuilds,
+                   swiftBuildArguments: swiftBuildArguments).subscribe { [weak self] state in
             self?.observer?(.spmManager(state))
         }
     }
@@ -34,19 +46,31 @@ public final class AllPackagesManager: ProgressObservable {
     private let carthageCommandPath: String
     private let swiftCommandPath: String
     private let frameworkKind: MergePackage.FrameworkKind
+    private let cacheBuilds: Bool
+    private let carthageArguments: String?
+    private let podArguments: String?
+    private let swiftBuildArguments: String?
 
     public init(depofile: Depofile,
                 platform: Platform,
                 podCommandPath: String,
                 carthageCommandPath: String,
                 swiftCommandPath: String,
-                frameworkKind: MergePackage.FrameworkKind) {
+                frameworkKind: MergePackage.FrameworkKind,
+                cacheBuilds: Bool,
+                carthageArguments: String?,
+                podArguments: String?,
+                swiftBuildArguments: String?) {
         self.depofile = depofile
         self.platform = platform
         self.podCommandPath = podCommandPath
         self.carthageCommandPath = carthageCommandPath
         self.swiftCommandPath = swiftCommandPath
         self.frameworkKind = frameworkKind
+        self.cacheBuilds = cacheBuilds
+        self.carthageArguments = carthageArguments
+        self.podArguments = podArguments
+        self.swiftBuildArguments = swiftBuildArguments
     }
 
     public func subscribe(_ observer: @escaping (State) -> Void) -> AllPackagesManager {

--- a/Sources/DepoCore/PackageManagers/CarthageManager.swift
+++ b/Sources/DepoCore/PackageManagers/CarthageManager.swift
@@ -33,7 +33,8 @@ public final class CarthageManager: ProgressObservable {
     private let cacheBuilds: Bool
     private let carthageArguments: String?
     private var carthageArgs: [CarthageShellCommand.BuildArgument] {
-        [.platform(platform)] + cacheBuilds.mapTrue(to: CarthageShellCommand.BuildArgument.cacheBuilds).array
+        let cacheBuilds = self.cacheBuilds.mapTrue(to: CarthageShellCommand.BuildArgument.cacheBuilds).array
+        return cacheBuilds + [.platform(platform), .custom(args: carthageArguments ?? "")]
     }
 
     public init(depofile: Depofile, platform: Platform, carthageCommandPath: String, cacheBuilds: Bool, carthageArguments: String?) {
@@ -66,7 +67,7 @@ public final class CarthageManager: ProgressObservable {
 
     public func build() throws {
         observer?(.building)
-        try carthageShellCommand.build()
+        try carthageShellCommand.build(arguments: carthageArgs)
     }
 
     private func createCartfile(at cartfilePath: String, with items: [CarthageItem]) throws {

--- a/Sources/DepoCore/PackageManagers/CarthageManager.swift
+++ b/Sources/DepoCore/PackageManagers/CarthageManager.swift
@@ -76,25 +76,5 @@ public final class CarthageManager: ProgressObservable {
         if !FileManager.default.createFile(atPath: cartfilePath, contents: content) {
             throw Error.badCartfile(path: cartfilePath)
         }
-        var t: Int? = 1
-    }
-}
-
-extension Bool {
-    func mapTrue<T>(to value: T) -> T? {
-        if self {
-            return value
-        }
-        else {
-            return nil
-        }
-    }
-}
-
-extension Optional {
-    var array: [Wrapped] {
-        map { wrapped in
-            [wrapped]
-        } ?? []
     }
 }

--- a/Sources/DepoCore/PackageManagers/CarthageManager.swift
+++ b/Sources/DepoCore/PackageManagers/CarthageManager.swift
@@ -30,11 +30,15 @@ public final class CarthageManager: ProgressObservable {
     private let shell: Shell = .init()
     private let carthageShellCommand: CarthageShellCommand
     private var observer: ((State) -> Void)?
+    private let cacheBuilds: Bool
+    private let carthageArguments: String?
 
-    public init(depofile: Depofile, platform: Platform, carthageCommandPath: String) {
+    public init(depofile: Depofile, platform: Platform, carthageCommandPath: String, cacheBuilds: Bool, carthageArguments: String?) {
         self.carthageItems = depofile.carts
         self.platform = platform
         self.carthageShellCommand = .init(commandPath: carthageCommandPath, shell: shell)
+        self.cacheBuilds = cacheBuilds
+        self.carthageArguments = carthageArguments
         self.shell.subscribe { [weak self] state in
             self?.observer?(.shell(state: state))
         }

--- a/Sources/DepoCore/PackageManagers/PodManager.swift
+++ b/Sources/DepoCore/PackageManagers/PodManager.swift
@@ -52,7 +52,11 @@ public final class PodManager: ProgressObservable {
     }
     private var observer: ((State) -> Void)?
 
-    public init(depofile: Depofile, podCommandPath: String, frameworkKind: MergePackage.FrameworkKind, cacheBuilds: Bool, podArguments: String?) {
+    public init(depofile: Depofile,
+                podCommandPath: String,
+                frameworkKind: MergePackage.FrameworkKind,
+                cacheBuilds: Bool,
+                podArguments: String?) {
         self.pods = depofile.pods
         self.podShellCommand = .init(commandPath: podCommandPath, shell: shell)
         self.frameworkKind = frameworkKind

--- a/Sources/DepoCore/PackageManagers/PodManager.swift
+++ b/Sources/DepoCore/PackageManagers/PodManager.swift
@@ -79,7 +79,7 @@ public final class PodManager: ProgressObservable {
 
         try podInitIfNeeded(podFilePath: podFilePath)
         try createPodfile(at: podFilePath, with: pods, buildSettings: .init(shell: shell))
-        try podShellCommand.install()
+        try podShellCommand.install(args: podArguments.mapOrEmpty(keyPath: \.words))
         observer?(.building)
         try build(pods: pods, frameworkKind: frameworkKind, at: podsProjectPath)
         try proceedAllPods(at: podsProjectPath, frameworkKind: frameworkKind, to: podsOutputDirectoryName)
@@ -91,7 +91,7 @@ public final class PodManager: ProgressObservable {
         let podsProjectPath = "./\(podsDirectoryName)"
 
         try createPodfile(at: podFilePath, with: pods, buildSettings: .init(shell: shell))
-        try podShellCommand.update()
+        try podShellCommand.update(args: podArguments.mapOrEmpty(keyPath: \.words))
         observer?(.building)
         try build(pods: pods, frameworkKind: frameworkKind, at: podsProjectPath)
         #warning("proceeding all pods seems redundant")

--- a/Sources/DepoCore/PackageManagers/PodManager.swift
+++ b/Sources/DepoCore/PackageManagers/PodManager.swift
@@ -45,15 +45,19 @@ public final class PodManager: ProgressObservable {
     private let shell: Shell = .init()
     private let podShellCommand: PodShellCommand
     private let frameworkKind: MergePackage.FrameworkKind
+    private let cacheBuilds: Bool
+    private let podArguments: String?
     private lazy var mergePackage: MergePackage = MergePackage(shell: shell).subscribe { [weak self] state in
         self?.observer?(.merge(state: state))
     }
     private var observer: ((State) -> Void)?
 
-    public init(depofile: Depofile, podCommandPath: String, frameworkKind: MergePackage.FrameworkKind) {
+    public init(depofile: Depofile, podCommandPath: String, frameworkKind: MergePackage.FrameworkKind, cacheBuilds: Bool, podArguments: String?) {
         self.pods = depofile.pods
         self.podShellCommand = .init(commandPath: podCommandPath, shell: shell)
         self.frameworkKind = frameworkKind
+        self.cacheBuilds = cacheBuilds
+        self.podArguments = podArguments
         self.shell.subscribe { [weak self] state in
             self?.observer?(.shell(state: state))
         }

--- a/Sources/DepoCore/PackageManagers/SPMManager.swift
+++ b/Sources/DepoCore/PackageManagers/SPMManager.swift
@@ -65,7 +65,7 @@ public final class SPMManager: ProgressObservable {
         self.packages = depofile.swiftPackages
         swiftPackageCommand = .init(commandPath: swiftCommandPath, shell: shell)
         self.frameworkKind = frameworkKind
-        self.cacheBuilds = cacheBuilds               
+        self.cacheBuilds = cacheBuilds
         self.swiftBuildArguments = swiftBuildArguments
         self.shell.subscribe { [weak self] state in
             self?.observer?(.shell(state: state))

--- a/Sources/DepoCore/PackageManagers/SPMManager.swift
+++ b/Sources/DepoCore/PackageManagers/SPMManager.swift
@@ -81,7 +81,7 @@ public final class SPMManager: ProgressObservable {
         observer?(.updating)
         let buildSettings = try BuildSettings(shell: shell)
         try createPackageSwiftFile(at: packageSwiftFileName, with: packages, buildSettings: buildSettings)
-        try swiftPackageCommand.update()
+        try swiftPackageCommand.update(args: swiftBuildArguments.mapOrEmpty(keyPath: \.words))
         observer?(.building)
         try build(packages: packages,
                   like: frameworkKind,

--- a/Sources/DepoCore/PackageManagers/SPMManager.swift
+++ b/Sources/DepoCore/PackageManagers/SPMManager.swift
@@ -52,13 +52,21 @@ public final class SPMManager: ProgressObservable {
     private let packageSwiftBuildsDirName = AppConfiguration.Path.Relative.packageSwiftBuildsDirectory
     private let outputDirName = AppConfiguration.Path.Relative.packageSwiftOutputDirectory
     private let frameworkKind: MergePackage.FrameworkKind
+    private let cacheBuilds: Bool
+    private let swiftBuildArguments: String?
     private var observer: ((State) -> Void)?
     private let productExtensions: [String] = ["framework", "xcframework"]
 
-    public init(depofile: Depofile, swiftCommandPath: String, frameworkKind: MergePackage.FrameworkKind) {
+    public init(depofile: Depofile,
+                swiftCommandPath: String,
+                frameworkKind: MergePackage.FrameworkKind,
+                cacheBuilds: Bool,
+                swiftBuildArguments: String?) {
         self.packages = depofile.swiftPackages
         swiftPackageCommand = .init(commandPath: swiftCommandPath, shell: shell)
         self.frameworkKind = frameworkKind
+        self.cacheBuilds = cacheBuilds               
+        self.swiftBuildArguments = swiftBuildArguments
         self.shell.subscribe { [weak self] state in
             self?.observer?(.shell(state: state))
         }

--- a/Sources/DepoCore/Shell/AnyArguments.swift
+++ b/Sources/DepoCore/Shell/AnyArguments.swift
@@ -11,18 +11,14 @@ public struct AnyArgument<Root> {
     init<T>(optionalKeyPath: KeyPath<Root, T?>, _ key: String, _ map: @escaping (T) -> String = { "\($0)" }) {
         value = { root in
             root[keyPath: optionalKeyPath].map { value in
-                (key + map(value)).split(separator: " ").map { substring in
-                    String(substring)
-                }
+                (key + map(value)).words
             } ?? []
         }
     }
 
     init<T>(_ keyPath: KeyPath<Root, T>, _ key: String, _ map: @escaping (T) -> String = { "\($0)" }) {
         value = { root -> [String] in
-            (key + map(root[keyPath: keyPath])).split(separator: " ").map { substring in
-                String(substring)
-            }
+            (key + map(root[keyPath: keyPath])).words
         }
     }
 }

--- a/Sources/DepoCore/Shell/CarthageShellCommand.swift
+++ b/Sources/DepoCore/Shell/CarthageShellCommand.swift
@@ -21,9 +21,7 @@ public final class CarthageShellCommand: ShellCommand {
             case .cacheBuilds:
                 return ["--cache-builds"]
             case let .custom(args):
-                return args.split(separator: " ").map { substring in
-                    String(substring)
-                }
+                return args.words
             }
         }
 

--- a/Sources/DepoCore/Shell/CarthageShellCommand.swift
+++ b/Sources/DepoCore/Shell/CarthageShellCommand.swift
@@ -12,6 +12,7 @@ public final class CarthageShellCommand: ShellCommand {
     public enum BuildArgument {
         case platform(Platform)
         case cacheBuilds
+        case custom(args: String)
 
         public var arguments: [String] {
             switch self {
@@ -19,6 +20,10 @@ public final class CarthageShellCommand: ShellCommand {
                 return platformArguments(platform: platform)
             case .cacheBuilds:
                 return ["--cache-builds"]
+            case let .custom(args):
+                return args.split(separator: " ").map { substring in
+                    String(substring)
+                }
             }
         }
 
@@ -43,8 +48,8 @@ public final class CarthageShellCommand: ShellCommand {
     }
 
     @discardableResult
-    public func build() throws -> Shell.IO {
-        try carthage("build", arguments: [])
+    public func build(arguments: [BuildArgument]) throws -> Shell.IO {
+        try carthage("build", arguments: arguments)
     }
 
     public func cartfile(url: URL) throws -> Cartfile {

--- a/Sources/DepoCore/Shell/CarthageShellCommand.swift
+++ b/Sources/DepoCore/Shell/CarthageShellCommand.swift
@@ -18,7 +18,7 @@ public final class CarthageShellCommand: ShellCommand {
             case let .platform(platform):
                 return platformArguments(platform: platform)
             case .cacheBuilds:
-                return ["--cache builds"]
+                return ["--cache-builds"]
             }
         }
 

--- a/Sources/DepoCore/Shell/PodShellCommand.swift
+++ b/Sources/DepoCore/Shell/PodShellCommand.swift
@@ -23,13 +23,13 @@ public final class PodShellCommand: ShellCommand {
     }
 
     @discardableResult
-    public func install() throws -> Shell.IO {
-        try shell(commandPath, "install")
+    public func install(args: [String]) throws -> Shell.IO {
+        try shell([commandPath, "install"] + args)
     }
 
     @discardableResult
-    public func update() throws -> Shell.IO {
-        try shell(commandPath, "update")
+    public func update(args: [String]) throws -> Shell.IO {
+        try shell([commandPath, "update"] + args)
     }
 
     public func podfile(buildSettings: BuildSettings, podfilePath: String) throws -> PodFile {

--- a/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
+++ b/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
@@ -58,11 +58,11 @@ public final class SwiftPackageShellCommand: ShellCommand {
 
     @discardableResult
     public func generateXcodeproj() throws -> Shell.IO {
-        try shell("swift", "package", "generate-xcodeproj")
+        try shell(commandPath, "package", "generate-xcodeproj")
     }
 
     public func spmVersion() throws -> String {
-        let swiftVersionOutput: Shell.IO = try shell("swift", "package", "--version")
+        let swiftVersionOutput: Shell.IO = try shell(commandPath, "package", "--version")
         let output = swiftVersionOutput.stdOut
         guard let keyRange = output.range(of: #"Swift Package Manager - Swift "#, options: .regularExpression),
               let valueRange = output[from: keyRange.upperBound].range(of: #"([^\s]+)"#, options: .regularExpression) else {
@@ -81,7 +81,7 @@ public final class SwiftPackageShellCommand: ShellCommand {
 
     private func jsonerOutput(at path: String, fmg: FileManager = .default) throws -> SPOutputWrapper {
         let output = try fmg.perform(atPath: path) {
-            try shell("swift", "package", "dump-package")
+            try shell(commandPath, "package", "dump-package")
         }
         return try JSONDecoder().decode(SPOutputWrapper.self, from: output.stdOut.data(using: .utf8) ?? Data())
     }

--- a/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
+++ b/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
@@ -34,8 +34,8 @@ public final class SwiftPackageShellCommand: ShellCommand {
     }
 
     @discardableResult
-    public func update() throws -> Shell.IO {
-        try shell(commandPath, "package", "update")
+    public func update(args: [String]) throws -> Shell.IO {
+        try shell([commandPath, "package", "update"] + args)
     }
 
     public func packageSwift(buildSettings: BuildSettings, path: String) throws -> PackageSwift {


### PR DESCRIPTION
# Related to #20 issue

### Description
In this PR:
- Allow to use `--cache-builds` flag for `carthage` command
- Add "free form" argument for each package manager. In other words, allow to specify arguments, which aren't handled by depo. 

> For example you want to pass `--no-skip-current` flag to carthage, but `depo carthage build` doesn't have that argument. Now you can do it like this: `depo carthage build --c ' --no-skip-current'`. Same for spm and pods

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Follows code style
- [x] Has no SwiftLint warnings
- [ ] Covered by tests
- [ ] All tests are passed
- [x] Access control words were checked
