### PR TITLE
static libraries from swift projects

### DIFF
--- a/Sources/Depo/Commands/Build.swift
+++ b/Sources/Depo/Commands/Build.swift
@@ -18,7 +18,7 @@ extension Build {
         let packages: [Manager.Package] = depofile[keyPath: Manager.keyPath]
         let manager = try wrapper.wrap(packages: packages,
                                        cacheBuilds: options.cacheBuilds,
-                                       cacheURL: depofile.cacheURL) { packages in
+                                       cacheURL: depofile.cacheURL) { _ in
             Manager(depofile: depofile, options: options).subscribe { state in
                 print(state)
             }

--- a/Sources/Depo/Commands/Depo.swift
+++ b/Sources/Depo/Commands/Depo.swift
@@ -51,6 +51,7 @@ final class Depo: ParsableCommand {
                                                                          Carthage.self,
                                                                          SPM.self,
                                                                          Cacher.self,
+                                                                         LibA.self,
                                                                          Example.self],
                                                            defaultSubcommand: AllInstall.self)
 }

--- a/Sources/Depo/Commands/Install.swift
+++ b/Sources/Depo/Commands/Install.swift
@@ -18,7 +18,7 @@ extension Install {
         let packages: [Manager.Package] = depofile[keyPath: Manager.keyPath]
         let manager = try wrapper.wrap(packages: packages,
                                        cacheBuilds: options.cacheBuilds,
-                                       cacheURL: depofile.cacheURL) { packages in
+                                       cacheURL: depofile.cacheURL) { _ in
             Manager(depofile: depofile, options: options).subscribe { state in
                 print(state)
             }

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -93,14 +93,3 @@ final class LibA: ParsableCommand {
         }
     }
 }
-
-extension Path {
-    var folder: Path? {
-        guard !isDirectory else {
-            return nil
-        }
-        var output = description
-        output.removeLast(lastComponent.count)
-        return Path(output)
-    }
-}

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -9,6 +9,9 @@ import PathKit
 
 final class LibA: ParsableCommand {
 
+    static let configuration: CommandConfiguration = .init(commandName: "liba",
+                                                               abstract: "build static library fro swift project")
+
     @Option
     var scheme: String
 

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -10,7 +10,7 @@ import PathKit
 final class LibA: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(commandName: "liba",
-                                                           abstract: "build static library fro swift project")
+                                                           abstract: "build static library from swift project")
 
     @Option(completion: .file())
     var swiftCommandPath: String = AppConfiguration.Path.Absolute.swiftCommandPath

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -1,0 +1,94 @@
+//
+// Copyright © 2020 Rosberry. All rights reserved.
+//
+
+import Foundation
+import ArgumentParser
+import DepoCore
+import PathKit
+
+final class LibA: ParsableCommand {
+
+    @Option
+    var scheme: String
+
+    @Option
+    var derivedDataPath: String
+
+    private let shell: Shell = Shell().subscribe { state in
+        print(state)
+    }
+    private lazy var xcodebuild: XcodeBuild = .init(shell: shell)
+    private lazy var lipo: Lipo = .init(shell: shell)
+
+    func run() throws {
+        try build(scheme: scheme)
+        let productPaths = Path.glob("\(derivedDataPath)/Build/Products/*")
+        let libs = try productPaths.map { productPath in
+            try makeStaticLibrary(productPath: productPath, name: "lib\(scheme).a")
+        }
+        let fatLib = try makeFatStaticLibrary(smallLibs: libs, name: "\(scheme).lib")
+        try collectSwiftModules(productPaths: productPaths, output: fatLib)
+        print(fatLib)
+    }
+
+    private func build(scheme: String) throws {
+        let simSettings = XcodeBuild.Settings.simulator(scheme: scheme,
+                                                        derivedDataPath: derivedDataPath,
+                                                        isSigning: false)
+        let devSettings = XcodeBuild.Settings.device(scheme: scheme,
+                                                     derivedDataPath: derivedDataPath,
+                                                     isSigning: false)
+        _ = try xcodebuild.buildForDistribution(settings: simSettings)
+        _ = try xcodebuild.buildForDistribution(settings: devSettings)
+    }
+
+    private func makeStaticLibrary(productPath: Path, name: String) throws -> Path {
+        let libPath = "\(productPath)\(name)"
+        let objects = productPath.glob("*.o")
+        _ = try shell(silent: "ar -rcs \(libPath) \(objects.map(by: \.description).spaceJoined)")
+        return Path(libPath)
+    }
+
+    private enum FatStaticLibError: Error {
+        case emptySmallLibs
+    }
+
+    private func makeFatStaticLibrary(smallLibs: [Path], name: String) throws -> Path {
+        guard let firstSmallLib = smallLibs.first else {
+            throw FatStaticLibError.emptySmallLibs
+        }
+        let libPath = Path("./\(name)")
+        try libPath.mkdir()
+        let outputPath = "\(libPath)/\(firstSmallLib.lastComponent)"
+        let executables = smallLibs.map(by: \.description)
+        try lipo(.create, outputPath, executables)
+        return libPath
+    }
+
+    private func collectSwiftModules(productPaths: [Path], output: Path) throws {
+        for productPath in productPaths {
+            let swiftModules = productPath.glob("*.swiftmodule")
+            for swiftModule in swiftModules {
+                let description = swiftModule.description
+                let swiftModulePathWithoutDashAtTheEnd = description[..<description.index(before: description.endIndex)]
+                _ = try shell(silent: "cp -r \(swiftModulePathWithoutDashAtTheEnd) \(output)")
+            }
+        }
+    }
+}
+
+class Builder {
+
+}
+
+extension Path {
+    var folder: Path? {
+        guard !isDirectory else {
+            return nil
+        }
+        var output = description
+        output.removeLast(lastComponent.count)
+        return Path(output)
+    }
+}

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -10,7 +10,10 @@ import PathKit
 final class LibA: ParsableCommand {
 
     static let configuration: CommandConfiguration = .init(commandName: "liba",
-                                                               abstract: "build static library fro swift project")
+                                                           abstract: "build static library fro swift project")
+
+    @Option(completion: .file())
+    var swiftCommandPath: String = AppConfiguration.Path.Absolute.swiftCommandPath
 
     @Option
     var scheme: String
@@ -23,7 +26,7 @@ final class LibA: ParsableCommand {
     }
 
     func run() throws {
-        let service = StaticLibraryBuilderService()
+        let service = StaticLibraryBuilderService(swiftCommandPath: swiftCommandPath)
         service.subscribe { state in
             print(state)
         }

--- a/Sources/Depo/Commands/LibA.swift
+++ b/Sources/Depo/Commands/LibA.swift
@@ -18,78 +18,14 @@ final class LibA: ParsableCommand {
     private let shell: Shell = Shell().subscribe { state in
         print(state)
     }
-    private lazy var xcodebuild: XcodeBuild = .init(shell: shell)
-    private lazy var lipo: Lipo = .init(shell: shell)
 
     func run() throws {
+        let service = StaticLibraryBuilderService()
+        service.subscribe { state in
+            print(state)
+        }
         let derivedDataPath = self.derivedDataPath ?? "\(scheme).derivedData"
-        try build(scheme: scheme, derivedDataPath: derivedDataPath)
-        let productPaths = Path.glob("\(derivedDataPath)/Build/Products/*")
-        let libs = try productPaths.map { productPath in
-            try makeStaticLibrary(productPath: productPath, name: "lib\(scheme).a")
-        }
-        let outputLibPath = Path("\(scheme).lib")
-        let tmpLibPath = Path("\(derivedDataPath)/\(scheme).lib")
-
-        try tmpLibPath.deleteIfExists()
-
-        try makeFatStaticLibrary(smallLibs: libs, at: tmpLibPath)
-        try collectSwiftModules(productPaths: productPaths, output: tmpLibPath)
-
-        try tmpLibPath.overwrite(outputLibPath)
-        print(outputLibPath)
-    }
-
-    private func build(scheme: String, derivedDataPath: String) throws {
-        let simSettings = XcodeBuild.Settings.simulator(scheme: scheme,
-                                                        derivedDataPath: derivedDataPath,
-                                                        isSigning: false)
-        let devSettings = XcodeBuild.Settings.device(scheme: scheme,
-                                                     derivedDataPath: derivedDataPath,
-                                                     isSigning: false)
-        _ = try xcodebuild(settings: simSettings)
-        _ = try xcodebuild(settings: devSettings)
-    }
-
-    private func makeStaticLibrary(productPath: Path, name: String) throws -> Path {
-        let libPath = "\(productPath)\(name)"
-        let objects = productPath.glob("*.o")
-        _ = try shell(silent: "ar -rcs \(libPath) \(objects.map(by: \.description).spaceJoined)")
-        return Path(libPath)
-    }
-
-    private enum FatStaticLibError: Error {
-        case emptySmallLibs
-    }
-
-    private func makeFatStaticLibrary(smallLibs: [Path], at libPath: Path) throws {
-        guard let firstSmallLib = smallLibs.first else {
-            throw FatStaticLibError.emptySmallLibs
-        }
-        try libPath.mkdir()
-        let outputPath = "\(libPath)/\(firstSmallLib.lastComponent)"
-        let executables = smallLibs.map(by: \.description)
-        try lipo(.create, outputPath, executables)
-        for smallLib in smallLibs {
-            try? smallLib.delete()
-        }
-    }
-
-    private enum CollectingSwiftModulesError: Error {
-        case noSwiftModules
-    }
-
-    private func collectSwiftModules(productPaths: [Path], output: Path) throws {
-        for productPath in productPaths {
-            let swiftModules = productPath.glob("*.swiftmodule")
-            guard !swiftModules.isEmpty else {
-                throw CollectingSwiftModulesError.noSwiftModules
-            }
-            for swiftModule in swiftModules {
-                let description = swiftModule.description
-                let swiftModulePathWithoutDashAtTheEnd = description[..<description.index(before: description.endIndex)]
-                _ = try shell(silent: "cp -r \(swiftModulePathWithoutDashAtTheEnd) \(output)")
-            }
-        }
+        let libPath = try service.build(scheme: scheme, derivedDataPath: derivedDataPath)
+        print("Done building \(string(libPath, color: .green))")
     }
 }

--- a/Sources/Depo/Commands/Update.swift
+++ b/Sources/Depo/Commands/Update.swift
@@ -18,7 +18,7 @@ extension Update {
         let packages: [Manager.Package] = depofile[keyPath: Manager.keyPath]
         let manager = try wrapper.wrap(packages: packages,
                                        cacheBuilds: options.cacheBuilds,
-                                       cacheURL: depofile.cacheURL) { packages in
+                                       cacheURL: depofile.cacheURL) { _ in
             Manager(depofile: depofile, options: options).subscribe { state in
                 print(state)
             }

--- a/Sources/Depo/UI/StaticLibraryBuilderService+UI.swift
+++ b/Sources/Depo/UI/StaticLibraryBuilderService+UI.swift
@@ -1,0 +1,23 @@
+//
+// Copyright © 2020 Rosberry. All rights reserved.
+//
+
+import Foundation
+import DepoCore
+
+extension StaticLibraryBuilderService.State: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .shell(state):
+            return state.description
+        case .buildSchemeForEachSDK:
+            return string("==> ", color: .cyan) + "Building scheme for each SDK"
+        case .makeStaticLibraryPerSDK:
+            return string("==> ", color: .cyan) + "Making static library for each SDK"
+        case .makeFatStaticLibrary:
+            return string("==> ", color: .cyan) + "Making fat static library"
+        case .collectingSwiftModules:
+            return string("==> ", color: .cyan) + "Collecting swiftmodules"
+        }
+    }
+}

--- a/Sources/DepoCore/Helpers/Path+Convenience.swift
+++ b/Sources/DepoCore/Helpers/Path+Convenience.swift
@@ -1,0 +1,19 @@
+//
+// Copyright © 2020 Rosberry. All rights reserved.
+//
+
+import PathKit
+
+public extension Path {
+
+    func overwrite(_ path: Path) throws {
+        try path.deleteIfExists()
+        try move(path)
+    }
+
+    func deleteIfExists() throws {
+        if exists {
+            try delete()
+        }
+    }
+}

--- a/Sources/DepoCore/Helpers/Path+Convenience.swift
+++ b/Sources/DepoCore/Helpers/Path+Convenience.swift
@@ -6,6 +6,15 @@ import PathKit
 
 public extension Path {
 
+    var folder: Path? {
+        guard !isDirectory else {
+            return nil
+        }
+        var output = description
+        output.removeLast(lastComponent.count)
+        return Path(output)
+    }
+
     func overwrite(_ path: Path) throws {
         try path.deleteIfExists()
         try move(path)

--- a/Sources/DepoCore/PackageManagers/AnyPackageManager.swift
+++ b/Sources/DepoCore/PackageManagers/AnyPackageManager.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public struct AnyPackageManager<Package>: PackageManager {
     static public var keyPath: KeyPath<Depofile, [Package]> {
-        fatalError()
+        fatalError("AnyPackageManager.keyPath is not implemented")
     }
     static public var outputPath: String {
         ""

--- a/Sources/DepoCore/PackageManagers/ConditionalPackageManager.swift
+++ b/Sources/DepoCore/PackageManagers/ConditionalPackageManager.swift
@@ -15,7 +15,7 @@ struct ConditionalPackageManager<PM: PackageManager>: PackageManager {
         PM.outputPath
     }
     static var keyPath: KeyPath<Depofile, [PM.Package]> {
-        fatalError()
+        fatalError("ConditionalPackageManager.keyPath is not implemented")
     }
     let packages: [Package]
     let packageManagerFactory: ([PM.Package]) -> PM
@@ -50,4 +50,3 @@ struct ConditionalPackageManager<PM: PackageManager>: PackageManager {
         }
     }
 }
-

--- a/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
+++ b/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
@@ -30,6 +30,7 @@ public final class StaticLibraryBuilderService: ProgressObservable {
     }
 
     public func build(scheme: String, derivedDataPath: String) throws -> Output {
+        try deleteXcprojectAndXcworskpaces()
         try buildSmallLibs(scheme: scheme, derivedDataPath: derivedDataPath)
 
         let sdkBuildOutputs = Path.glob("\(derivedDataPath)/Build/Products/*")
@@ -51,6 +52,14 @@ public final class StaticLibraryBuilderService: ProgressObservable {
     public func subscribe(_ observer: @escaping (State) -> Void) -> Self {
         self.observer = observer
         return self
+    }
+
+    private func deleteXcprojectAndXcworskpaces() throws {
+        let projects = Path.glob("*.xcproject")
+        let workspaces = Path.glob("*.xcworkspace")
+        for item in (projects + workspaces) {
+            try item.delete()
+        }
     }
 
     private func buildSmallLibs(scheme: String, derivedDataPath: String) throws {

--- a/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
+++ b/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
@@ -1,0 +1,118 @@
+//
+// Copyright © 2020 Rosberry. All rights reserved.
+//
+
+import Foundation
+import PathKit
+
+public final class StaticLibraryBuilderService: ProgressObservable {
+
+    public typealias Output = String
+
+    public enum State {
+        case shell(state: Shell.State)
+        case buildSchemeForEachSDK
+        case makeStaticLibraryPerSDK
+        case makeFatStaticLibrary
+        case collectingSwiftModules
+    }
+
+    private var observer: ((State) -> Void)?
+    private lazy var xcodebuild: XcodeBuild = .init(shell: shell)
+    private lazy var lipo: Lipo = .init(shell: shell)
+
+    private lazy var shell: Shell = Shell().subscribe { [weak self] state in
+        self?.observer?(.shell(state: state))
+    }
+
+    public init() {
+
+    }
+
+    public func build(scheme: String, derivedDataPath: String) throws -> Output {
+        try buildSmallLibs(scheme: scheme, derivedDataPath: derivedDataPath)
+
+        let sdkBuildOutputs = Path.glob("\(derivedDataPath)/Build/Products/*")
+
+        let staticLibsPerSDK = try makeStaticLibForEachSDK(sdkBuildOutputs: sdkBuildOutputs, scheme: scheme)
+        let outputLibPath = Path("\(scheme).lib")
+        let tmpLibPath = Path("\(derivedDataPath)/\(scheme).lib")
+
+        try tmpLibPath.deleteIfExists()
+
+        try makeFatStaticLibrary(smallLibs: staticLibsPerSDK, at: tmpLibPath)
+        try collectSwiftModules(productPaths: sdkBuildOutputs, output: tmpLibPath)
+
+        try tmpLibPath.overwrite(outputLibPath)
+        return outputLibPath.description
+    }
+
+    @discardableResult
+    public func subscribe(_ observer: @escaping (State) -> Void) -> Self {
+        self.observer = observer
+        return self
+    }
+
+    private func buildSmallLibs(scheme: String, derivedDataPath: String) throws {
+        observer?(.buildSchemeForEachSDK)
+        let simSettings = XcodeBuild.Settings.simulator(scheme: scheme,
+                                                        derivedDataPath: derivedDataPath,
+                                                        isSigning: false)
+        let devSettings = XcodeBuild.Settings.device(scheme: scheme,
+                                                     derivedDataPath: derivedDataPath,
+                                                     isSigning: false)
+        _ = try xcodebuild(settings: simSettings)
+        _ = try xcodebuild(settings: devSettings)
+    }
+
+    private func makeStaticLibForEachSDK(sdkBuildOutputs: [Path], scheme: String) throws -> [Path] {
+        observer?(.makeStaticLibraryPerSDK)
+        return try sdkBuildOutputs.map { buildOutputPath in
+            try makeStaticLibrary(productPath: buildOutputPath, name: "lib\(scheme).a")
+        }
+    }
+
+    private func makeStaticLibrary(productPath: Path, name: String) throws -> Path {
+        let libPath = "\(productPath)\(name)"
+        let objects = productPath.glob("*.o")
+        _ = try shell(silent: "ar -rcs \(libPath) \(objects.map(by: \.description).spaceJoined)")
+        return Path(libPath)
+    }
+
+    private enum FatStaticLibError: Error {
+        case emptySmallLibs
+    }
+
+    private func makeFatStaticLibrary(smallLibs: [Path], at libPath: Path) throws {
+        observer?(.makeFatStaticLibrary)
+        guard let firstSmallLib = smallLibs.first else {
+            throw FatStaticLibError.emptySmallLibs
+        }
+        try libPath.mkdir()
+        let outputPath = "\(libPath)/\(firstSmallLib.lastComponent)"
+        let executables = smallLibs.map(by: \.description)
+        try lipo(.create, outputPath, executables)
+        for smallLib in smallLibs {
+            try? smallLib.delete()
+        }
+    }
+
+    private enum CollectingSwiftModulesError: Error {
+        case noSwiftModules
+    }
+
+    private func collectSwiftModules(productPaths: [Path], output: Path) throws {
+        observer?(.collectingSwiftModules)
+        for productPath in productPaths {
+            let swiftModules = productPath.glob("*.swiftmodule")
+            guard !swiftModules.isEmpty else {
+                throw CollectingSwiftModulesError.noSwiftModules
+            }
+            for swiftModule in swiftModules {
+                let description = swiftModule.description
+                let swiftModulePathWithoutDashAtTheEnd = description[..<description.index(before: description.endIndex)]
+                _ = try shell(silent: "cp -r \(swiftModulePathWithoutDashAtTheEnd) \(output)")
+            }
+        }
+    }
+}

--- a/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
+++ b/Sources/DepoCore/Services/StaticLibraryBuilderService.swift
@@ -76,7 +76,7 @@ public final class StaticLibraryBuilderService: ProgressObservable {
     }
 
     private func deleteXcprojectAndXcworskpaces() throws {
-        let projects = Path.glob("*.xcproject")
+        let projects = Path.glob("*.xcodeproj")
         let workspaces = Path.glob("*.xcworkspace")
         for item in (projects + workspaces) {
             try item.delete()
@@ -109,11 +109,11 @@ public final class StaticLibraryBuilderService: ProgressObservable {
         return Path(libPath)
     }
 
-    private enum FatStaticLibError: Error {
-        case emptySmallLibs
-    }
-
     private func makeFatStaticLibrary(smallLibs: [Path], at libPath: Path) throws {
+        enum FatStaticLibError: Error {
+            case emptySmallLibs
+        }
+
         observer?(.makeFatStaticLibrary)
         guard let firstSmallLib = smallLibs.first else {
             throw FatStaticLibError.emptySmallLibs
@@ -127,11 +127,10 @@ public final class StaticLibraryBuilderService: ProgressObservable {
         }
     }
 
-    private enum CollectingSwiftModulesError: Error {
-        case noSwiftModules
-    }
-
     private func collectSwiftModules(productPaths: [Path], output: Path) throws {
+        enum CollectingSwiftModulesError: Error {
+            case noSwiftModules
+        }
         observer?(.collectingSwiftModules)
         for productPath in productPaths {
             let swiftModules = productPath.glob("*.swiftmodule")

--- a/Sources/DepoCore/Shell/Lipo.swift
+++ b/Sources/DepoCore/Shell/Lipo.swift
@@ -7,9 +7,15 @@ import Foundation
 public class Lipo: ShellCommand, ArgumentedShellCommand {
 
     public struct Settings: ShellCommandArguments {
-        let actionType: ActionType = .create
+        let actionType: ActionType
         let outputPath: String
         let executablePaths: [String]
+
+        init(actionType: ActionType = .create, outputPath: String, executablePaths: [String]) {
+            self.actionType = actionType
+            self.outputPath = outputPath
+            self.executablePaths = executablePaths
+        }
     }
 
     public enum ActionType: String {
@@ -31,5 +37,10 @@ public class Lipo: ShellCommand, ArgumentedShellCommand {
 
     public required init(from decoder: Decoder) throws {
         try super.init(from: decoder)
+    }
+
+    public func callAsFunction(_ actionType: ActionType, _ outputPath: String, _ executablePaths: [String]) throws -> String {
+        let settings = Settings(actionType: actionType, outputPath: outputPath, executablePaths: executablePaths)
+        return try self.callAsFunction(settings: settings)
     }
 }

--- a/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
+++ b/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
@@ -9,10 +9,10 @@ public final class SwiftPackageShellCommand: ShellCommand {
 
     typealias SPVersionConstraint = VersionConstraint<SwiftPackage.Operator>
 
-    fileprivate struct SPOutputWrapper: Codable {
-        let products: [Product]
-        let targets: [Target]
-        let dependencies: [Dependency]
+    public struct SPOutputWrapper: Codable {
+        public let products: [Product]
+        public let targets: [Target]
+        public let dependencies: [Dependency]
     }
 
     private struct Version {
@@ -68,6 +68,10 @@ public final class SwiftPackageShellCommand: ShellCommand {
             return ""
         }
         return String(output[valueRange])
+    }
+
+    public func swiftPackageDump(at path: String) throws -> SPOutputWrapper {
+        try jsonerOutput(at: path)
     }
 
     private func swiftPackageByJsoner(packageSwiftFilePath: String) throws -> [SwiftPackage] {
@@ -199,34 +203,35 @@ public final class SwiftPackageShellCommand: ShellCommand {
     }
 }
 
-extension SwiftPackageShellCommand.SPOutputWrapper {
-    fileprivate struct Dependency: Codable {
-        let name: String?
-        let url: URL
-        let requirement: Requirement
+public extension SwiftPackageShellCommand.SPOutputWrapper {
+    public struct Dependency: Codable {
+        public let  name: String?
+        public let  url: URL
+        public let  requirement: Requirement
     }
 
-    fileprivate struct Target: Codable {
+    public struct Target: Codable {
 
-        enum TypeEnum: String, Codable {
+        public enum TypeEnum: String, Codable {
             case regular
             case test
         }
 
-        let name: String
-        let type: TypeEnum
+        public let name: String
+        public let type: TypeEnum
+        public let path: String?
     }
 
-    fileprivate struct Product: Codable {
-        let name: String
-        let targets: [String]
+    public struct Product: Codable {
+        public let name: String
+        public let targets: [String]
     }
 }
 
-extension SwiftPackageShellCommand.SPOutputWrapper.Dependency {
-    fileprivate struct Requirement: Codable {
+public extension SwiftPackageShellCommand.SPOutputWrapper.Dependency {
+    public struct Requirement: Codable {
 
-        enum Kind: String, Codable {
+        public enum Kind: String, Codable {
             case range
             case exact
             case branch
@@ -234,19 +239,19 @@ extension SwiftPackageShellCommand.SPOutputWrapper.Dependency {
             case localPackage
         }
 
-        private enum CodingKeys: String, CodingKey {
+        public enum CodingKeys: String, CodingKey {
             case type
             case identifier
             case lowerBound
             case upperBound
         }
 
-        private struct RangeModel: Codable {
+        public struct RangeModel: Codable {
             let lowerBound: String
             let upperBound: String
         }
 
-        init(from decoder: Decoder) throws {
+        public init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             if let wrapper = try? container.decode([String: [RangeModel]].self),
                let range = wrapper.first?.value.first {
@@ -269,9 +274,9 @@ extension SwiftPackageShellCommand.SPOutputWrapper.Dependency {
             }
         }
 
-        let type: Kind
-        let identifier: String?
-        let lowerBound: String?
-        let upperBound: String?
+        public let type: Kind
+        public let identifier: String?
+        public let lowerBound: String?
+        public let upperBound: String?
     }
 }

--- a/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
+++ b/Sources/DepoCore/Shell/SwiftPackageShellCommand.swift
@@ -210,7 +210,7 @@ public extension SwiftPackageShellCommand.SPOutputWrapper {
         public let  requirement: Requirement
     }
 
-    public struct Target: Codable {
+    struct Target: Codable {
 
         public enum TypeEnum: String, Codable {
             case regular
@@ -222,7 +222,7 @@ public extension SwiftPackageShellCommand.SPOutputWrapper {
         public let path: String?
     }
 
-    public struct Product: Codable {
+    struct Product: Codable {
         public let name: String
         public let targets: [String]
     }

--- a/Sources/DepoCore/Shell/XcodeBuild.swift
+++ b/Sources/DepoCore/Shell/XcodeBuild.swift
@@ -20,6 +20,7 @@ public class XcodeBuild: ShellCommand, ArgumentedShellCommand {
         let isQuiet: Bool
         let derivedDataPath: String?
         let actionType: ActionType?
+        let isSigning: Bool
     }
 
     public enum Configuration: String, CustomStringConvertible {
@@ -65,7 +66,11 @@ public class XcodeBuild: ShellCommand, ArgumentedShellCommand {
              .init(optionalKeyPath: \.isOnlyActiveArch, "only-active-arch=", { $0.yesOrNo }),
              .init(\.isQuiet, "-quiet", { _ in "" }),
              .init(optionalKeyPath: \.derivedDataPath, "-derivedDataPath "),
-             .init(optionalKeyPath: \.actionType, "")]
+             .init(optionalKeyPath: \.actionType, ""),
+             .init(\.isSigning, "", { $0 ? "" : noSigningString })]
+    private static var noSigningString: String {
+        #"CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO""#
+    }
 
     public override init(commandPath: String = AppConfiguration.Path.Absolute.xcodebuild, shell: Shell) {
         super.init(commandPath: commandPath, shell: shell)
@@ -195,7 +200,9 @@ public class XcodeBuild: ShellCommand, ArgumentedShellCommand {
 
 extension XcodeBuild.Settings {
 
-    static func simulator(target: String, configuration: XcodeBuild.Configuration = .release) -> Self {
+    public static func simulator(target: String,
+                                 configuration: XcodeBuild.Configuration = .release,
+                                 isSigning: Bool = true) -> Self {
         XcodeBuild.Settings(target: target,
                             scheme: nil,
                             configuration: configuration,
@@ -205,10 +212,13 @@ extension XcodeBuild.Settings {
                             isOnlyActiveArch: false,
                             isQuiet: true,
                             derivedDataPath: nil,
-                            actionType: .archive)
+                            actionType: .archive,
+                            isSigning: isSigning)
     }
 
-    static func device(target: String, configuration: XcodeBuild.Configuration = .release) -> Self {
+    public static func device(target: String,
+                              configuration: XcodeBuild.Configuration = .release,
+                              isSigning: Bool = true) -> Self {
         XcodeBuild.Settings(target: target,
                             scheme: nil,
                             configuration: configuration,
@@ -218,39 +228,46 @@ extension XcodeBuild.Settings {
                             isOnlyActiveArch: nil,
                             isQuiet: true,
                             derivedDataPath: nil,
-                            actionType: .archive)
+                            actionType: .archive,
+                            isSigning: isSigning)
     }
 
-    static func simulator(scheme: String,
-                          configuration: XcodeBuild.Configuration = .release,
-                          derivedDataPath: String? = nil,
-                          actionType: XcodeBuild.ActionType? = nil) -> Self {
+    public static func simulator(scheme: String,
+                                 configuration: XcodeBuild.Configuration = .release,
+                                 isOnlyActiveArch: Bool? = false,
+                                 derivedDataPath: String? = nil,
+                                 actionType: XcodeBuild.ActionType? = nil,
+                                 isSigning: Bool = true) -> Self {
         XcodeBuild.Settings(target: nil,
                             scheme: scheme,
                             configuration: configuration,
                             isDefineModules: true,
                             sdk: .iphonesimulator,
                             arch: .x86_64,
-                            isOnlyActiveArch: false,
+                            isOnlyActiveArch: isOnlyActiveArch,
                             isQuiet: true,
                             derivedDataPath: derivedDataPath,
-                            actionType: actionType)
+                            actionType: actionType,
+                            isSigning: isSigning)
     }
 
-    static func device(scheme: String,
-                       configuration: XcodeBuild.Configuration = .release,
-                       derivedDataPath: String? = nil,
-                       actionType: XcodeBuild.ActionType? = nil) -> Self {
+    public static func device(scheme: String,
+                              configuration: XcodeBuild.Configuration = .release,
+                              isOnlyActiveArch: Bool? = nil,
+                              derivedDataPath: String? = nil,
+                              actionType: XcodeBuild.ActionType? = nil,
+                              isSigning: Bool = true) -> Self {
         XcodeBuild.Settings(target: nil,
                             scheme: scheme,
                             configuration: configuration,
                             isDefineModules: true,
                             sdk: .iphoneos,
                             arch: nil,
-                            isOnlyActiveArch: nil,
+                            isOnlyActiveArch: isOnlyActiveArch,
                             isQuiet: true,
                             derivedDataPath: derivedDataPath,
-                            actionType: actionType)
+                            actionType: actionType,
+                            isSigning: isSigning)
     }
 }
 

--- a/swift-build-lib
+++ b/swift-build-lib
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+scheme=$1
+
+# building 
+xcodebuild archive -scheme $scheme -sdk iphoneos -derivedDataPath iphoneos -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+
+xcodebuild archive -scheme $scheme -sdk iphonesimulator -derivedDataPath iphonesimulator -configuration Release -arch x86_64 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+
+function make_static_lib {
+  path=$1
+  name=$2
+  objects=$path/*.o
+  output=$path/lib$name.a
+  ar -rcs $output $objects
+}
+
+simulator_build=iphonesimulator/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release-iphonesimulator
+device_build=iphoneos/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release-iphoneos
+
+# making libs
+make_static_lib $simulator_build $scheme
+make_static_lib $device_build $scheme
+
+output_dir=$scheme.lib
+mkdir $output_dir
+
+# making fat lib
+lipo -create $simulator_build/lib$scheme.a $device_build/lib$scheme.a -output $output_dir/lib$scheme.a
+
+# merging swiftmodules
+swiftmodules=`ls -1 $device_build | grep ".swiftmodule"`
+
+for module in $swiftmodules
+do
+  mkdir $output_dir/$module
+  cp -r $simulator_build/$module/* $output_dir/$module
+  cp -r $device_build/$module/*    $output_dir/$module
+done
+
+# merging modulemaps
+cat iphoneos/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/IntermediateBuildFilesPath/GeneratedModuleMaps-iphoneos/*.modulemap > $output_dir/module.modulemap


### PR DESCRIPTION
# Description
Implement building static (lib<NAME>.a) libraries from swift/xcode project.

lib<NAME>.a cannot be integrated to xcodeproject as it -- the meta files (swiftmodules) are required. Due to that, the output of `depo liba --scheme <SCHEME>` is <SCHEME>.lib folder, which contains swiftmodules and static library

# TBD
- connect liba subcommand to spm
- cache our internal libs as static libs
- handle Carthage/Cocoapod dependencies 