### PR TITLE
Add --use-xcframeworks as default Carthage arg

### DIFF
--- a/Sources/DepoCore/PackageManagers/ConditionalPackageManager.swift
+++ b/Sources/DepoCore/PackageManagers/ConditionalPackageManager.swift
@@ -2,10 +2,19 @@
 // Copyright © 2020 Rosberry. All rights reserved.
 //
 
+import Foundation
+
 struct ConditionalPackageManager<PM: PackageManager>: PackageManager {
 
-    public enum Error: Swift.Error {
-        case noPackages
+    public enum Error: Swift.Error, LocalizedError {
+        case noPackages(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case let .noPackages(path):
+                return "No packages to build for \(path)"
+            }
+        }
     }
 
     typealias Package = PM.Package
@@ -27,7 +36,7 @@ struct ConditionalPackageManager<PM: PackageManager>: PackageManager {
 
     private func doIfNeeded<T>(action: () throws -> T) throws -> T {
         guard packages[keyPath: conditionKeyPath] else {
-            throw Error.noPackages
+            throw Error.noPackages(Self.outputPath)
         }
         return try action()
     }

--- a/Sources/DepoCore/Shell/CarthageShellCommand.swift
+++ b/Sources/DepoCore/Shell/CarthageShellCommand.swift
@@ -14,6 +14,7 @@ public final class CarthageShellCommand: ShellCommand {
         case cacheBuilds
         case custom(args: String)
         case ssh
+        case xcframeworks
 
         public var strings: [String] {
             switch self {
@@ -25,6 +26,8 @@ public final class CarthageShellCommand: ShellCommand {
                 return args.words
             case .ssh:
                 return ["--use-ssh"]
+            case .xcframeworks:
+                return ["--use-xcframeworks"]
             }
         }
 
@@ -62,7 +65,7 @@ public final class CarthageShellCommand: ShellCommand {
     }
 
     private func carthage(_ command: String, arguments: [BuildArgument]) throws -> Int32 {
-        let argumentsString = (arguments + [.ssh]).map(\.strings.spaceJoined).joined(separator: " ")
+        let argumentsString = (arguments + [.ssh, .xcframeworks]).map(\.strings.spaceJoined).joined(separator: " ")
         return try shell(loud: "\(commandPath) \(command) \(argumentsString)")
     }
 


### PR DESCRIPTION
Also, adds a user-friendly message if there's nothing to build for a specific dependency manager.